### PR TITLE
Update to new cloudfare mathjax cdn

### DIFF
--- a/main.js
+++ b/main.js
@@ -156,7 +156,7 @@ function TeXify () {
   document.head.appendChild(mathjaxConfig)
 
   require(['KaTeX/dist/katex.min',
-           '//cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-MML-AM_HTMLorMML',
+           '//cdnjs.cloudflare.com/ajax/libs/mathjax/2.7.1/MathJax.js?config=TeX-MML-AM_HTMLorMML',
            'baseline/baseline'], function (katex) {
     var maths = document.getElementsByClassName('math')
     for (i = 0; i < maths.length; i++) {


### PR DESCRIPTION
I did a conscious effort in April to trace all dependencies I had using the mathjax CDN, but TeX.js slipped through. As they announced, they had a CDN switch:
https://www.mathjax.org/cdn-shutting-down/

which leads to the assets I am loading for TeX.js through `https://davidar.io` to fail at loading mathjax and hence ended up with no math rendering. Luckily it's an easy fix - and I will also kindly ask that the davidar.io assets get an update if/when this PR gets merged.

Thanks!